### PR TITLE
Build for multiple platforms

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,110 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  build-win:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Vanilla
+      run: |
+        wget https://files.catbox.moe/i4sdl6.zip -O Vanilla.zip
+        unzip Vanilla.zip -d vanilla-15
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+    - name: Setup ms-build
+      run: sudo apt-get install -y nuget mono-devel mono-xbuild
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build MiniSavestates (Windows)
+      run: |
+        dotnet build
+    - name: Upload Windows Binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: MiniSavestatesWin
+        path: ./out-15/
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Vanilla
+      run: |
+        wget https://files.catbox.moe/j85bvb.zip -O Vanilla.zip
+        unzip Vanilla.zip -d vanilla-15
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+    - name: Setup ms-build
+      run: sudo apt-get install -y nuget mono-devel mono-xbuild
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build MiniSavestates (Linux)
+      run: |
+        dotnet build
+    - name: Upload Linux Binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: MiniSavestatesLinux
+        path: ./out-15/
+
+  build-mac:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Setup Vanilla
+      run: |
+        wget https://files.catbox.moe/j8fyro.zip -O Vanilla.zip
+        unzip Vanilla.zip -d vanilla-15
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+    - name: Setup ms-build
+      run: sudo apt-get install -y nuget mono-devel mono-xbuild
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build MiniSavestates (Mac)
+      run: |
+        dotnet build
+    - name: Upload Mac Binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: MiniSavestatesMac
+        path: ./out-15/
+
+  release:
+    needs: [build-win, build-linux, build-mac]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags')
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+      - name: Zip
+        run: |
+            zip -jr MiniSavestatesWin.zip ./artifacts/MiniSavestatesWin/*
+            zip -jr MiniSavestatesLinux.zip ./artifacts/MiniSavestatesLinux/*
+            zip -jr MiniSavestatesMac.zip ./artifacts/MiniSavestatesMac/*
+      - name: Generate release info
+        run: |
+            echo "# Checksums" > ChangeLog.txt ;
+            echo "* Linux:" >> ChangeLog.txt ;
+            echo -n "    * " >> ChangeLog.txt ;
+            sha256sum -b MiniSavestatesLinux.zip | cut -d " " -f 1 >> ChangeLog.txt ;
+            echo "* Mac:" >> ChangeLog.txt ;
+            echo -n "    * " >> ChangeLog.txt ;
+            sha256sum -b MiniSavestatesMac.zip | cut -d " " -f 1 >> ChangeLog.txt ;
+            echo "* Windows:" >> ChangeLog.txt ;
+            echo -n "    * " >> ChangeLog.txt ;
+            sha256sum -b MiniSavestatesWin.zip | cut -d " " -f 1 >> ChangeLog.txt ;
+            echo "# Changelog" >> ChangeLog.txt ;
+            echo "${{ github.event.head_commit.message }}" >> ChangeLog.txt ;
+      - name: Create release if a new tag is pushed
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: ChangeLog.txt
+          files: |
+            ./MiniSavestatesWin.zip
+            ./MiniSavestatesLinux.zip
+            ./MiniSavestatesMac.zip

--- a/MiniSavestates/MiniSavestates.csproj
+++ b/MiniSavestates/MiniSavestates.csproj
@@ -42,10 +42,14 @@
         <Files Include="$(SolutionDir)Vanilla/*" />
         <BuildDir Include="$(TargetDir)" />
     </ItemGroup>
+    <PropertyGroup>
+        <Mono Condition="$(OS) == WINDOWS_NT" />
+        <Mono Condition="$(OS) != WINDOWS_NT">mono</Mono>
+    </PropertyGroup>
     <Target Name="PostBuild" AfterTargets="PostBuildEvent">
         <Copy SkipUnchangedFiles="true" SourceFiles="@(Files)" DestinationFolder="@(BuildDir)" />
         <Delete Condition="Exists('MONOMODDED_Assembly-CSharp.dll')" Files="MONOMODDED_Assembly-CSharp.dll" />
-        <Exec WorkingDirectory="@(BuildDir)" Command="MonoMod.exe Assembly-CSharp.dll" />
+        <Exec WorkingDirectory="@(BuildDir)" Command="$(Mono) MonoMod.exe Assembly-CSharp.dll" />
         <Copy SourceFiles="$(TargetDir)/MONOMODDED_Assembly-CSharp.dll" DestinationFiles="$(SolutionDir)/out-$(Branch)/Assembly-CSharp.dll" />
     </Target>
 </Project>

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ When you save a state it gets saved to the file `<saves location>/minisavestates
 
 ### Building
 
-1. Copy vanilla managed folder into a new folder named `vanilla` in this repository.
+1. Copy vanilla managed folder into a new folder named `vanilla-15` in this repository.
 2. run `dotnet build`.
-3. The output will be in `out`.
+3. The output will be in `out-15`.


### PR DESCRIPTION
This PR adds support for non-Windows platforms, and adds a Github-Actions Workflow to build it for Windows, Mac, and Linux, based on the Github-Actions Workflow used by the Modding API.

Tested on Mac.

Edit: now tested on Mac, Windows, and Linux through WSL.